### PR TITLE
Proof of concept: CPU+GPU shared kernels.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,3 +1,5 @@
+# This file is machine-generated - editing it directly is not advised
+
 [[AbstractFFTs]]
 deps = ["Compat", "LinearAlgebra"]
 git-tree-sha1 = "8d59c3b1463b5e0ad05a3698167f85fac90e184d"
@@ -13,17 +15,41 @@ git-tree-sha1 = "055eb2690182ebc31087859c3dd8598371d3ef9e"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 version = "0.5.3"
 
+[[ColorTypes]]
+deps = ["FixedPointNumbers", "Random", "Test"]
+git-tree-sha1 = "f73b0e10f2a5756de7019818a41654686da06b09"
+uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+version = "0.7.5"
+
+[[Colors]]
+deps = ["ColorTypes", "FixedPointNumbers", "InteractiveUtils", "Printf", "Reexport", "Test"]
+git-tree-sha1 = "9f0a0210450acb91c730b730a994f8eef1d3d543"
+uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
+version = "0.9.5"
+
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "ec61a16eed883ad0cfa002d7489b3ce6d039bb9a"
+git-tree-sha1 = "49269e311ffe11ac5b334681d212329002a9832a"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "1.4.0"
+version = "1.5.1"
 
 [[Conda]]
 deps = ["Compat", "JSON", "VersionParsing"]
-git-tree-sha1 = "fb86fe40cb5b35990e368709bfdc1b46dbb99dac"
+git-tree-sha1 = "b625d802587c2150c279a40a646fba63f9bd8187"
 uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
-version = "1.1.1"
+version = "1.2.0"
+
+[[Contour]]
+deps = ["LinearAlgebra", "StaticArrays", "Test"]
+git-tree-sha1 = "b974e164358fea753ef853ce7bad97afec15bb80"
+uuid = "d38c429a-6771-53c6-b99e-75d170b6e991"
+version = "0.5.1"
+
+[[DataStructures]]
+deps = ["InteractiveUtils", "OrderedCollections", "Random", "Serialization", "Test"]
+git-tree-sha1 = "ca971f03e146cf144a9e2f2ce59674f5bf0e8038"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.15.0"
 
 [[Dates]]
 deps = ["Printf"]
@@ -34,7 +60,7 @@ deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[Distributed]]
-deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[DocStringExtensions]]
@@ -55,8 +81,20 @@ git-tree-sha1 = "29cda58afbf62f35b1a094882ad6c745a47b2eaa"
 uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 version = "0.2.4"
 
+[[FixedPointNumbers]]
+deps = ["Test"]
+git-tree-sha1 = "b8045033701c3b10bf2324d7203404be7aef88ba"
+uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+version = "0.5.3"
+
+[[GR]]
+deps = ["Base64", "DelimitedFiles", "LinearAlgebra", "Pkg", "Printf", "Random", "Serialization", "Sockets", "Test"]
+git-tree-sha1 = "3c62c19ddf86ff016829fdac1663cd3c75558c34"
+uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
+version = "0.37.0"
+
 [[InteractiveUtils]]
-deps = ["LinearAlgebra", "Markdown"]
+deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JSON]]
@@ -82,12 +120,54 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[Measures]]
+deps = ["Test"]
+git-tree-sha1 = "ddfd6d13e330beacdde2c80de27c1c671945e7d9"
+uuid = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
+version = "0.3.0"
+
+[[Missings]]
+deps = ["Dates", "InteractiveUtils", "SparseArrays", "Test"]
+git-tree-sha1 = "d1d2585677f2bd93a97cfeb8faa7a0de0f982042"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "0.4.0"
+
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[NaNMath]]
+deps = ["Compat"]
+git-tree-sha1 = "ce3b85e484a5d4c71dd5316215069311135fa9f2"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "0.3.2"
+
+[[OrderedCollections]]
+deps = ["Random", "Serialization", "Test"]
+git-tree-sha1 = "85619a3f3e17bb4761fe1b1fd47f0e979f964d5b"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.0.2"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[PlotThemes]]
+deps = ["PlotUtils", "Requires", "Test"]
+git-tree-sha1 = "f3afd2d58e1f6ac9be2cea46e4a9083ccc1d990b"
+uuid = "ccf2f8ad-2431-5c83-bf29-c5338b663b6a"
+version = "0.3.0"
+
+[[PlotUtils]]
+deps = ["Colors", "Dates", "Printf", "Random", "Reexport", "Test"]
+git-tree-sha1 = "fd28f30a294a38ec847de95d8ac7ac916ccd7c06"
+uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
+version = "0.5.5"
+
+[[Plots]]
+deps = ["Base64", "Contour", "Dates", "FixedPointNumbers", "GR", "JSON", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "Reexport", "Requires", "Showoff", "SparseArrays", "StaticArrays", "Statistics", "StatsBase", "Test", "UUIDs"]
+git-tree-sha1 = "1c345ad538fa31ea6953d89a9d0cbef21e86a3ed"
+uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+version = "0.23.0"
 
 [[Printf]]
 deps = ["Unicode"]
@@ -101,11 +181,23 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
+[[RecipesBase]]
+deps = ["Random", "Test"]
+git-tree-sha1 = "0b3cb370ee4dc00f47f1193101600949f3dcf884"
+uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+version = "0.6.0"
+
 [[Reexport]]
 deps = ["Pkg"]
 git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 version = "0.2.0"
+
+[[Requires]]
+deps = ["Test"]
+git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "0.5.2"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -117,23 +209,47 @@ uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 deps = ["Distributed", "Mmap", "Random", "Serialization"]
 uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 
+[[Showoff]]
+deps = ["Compat"]
+git-tree-sha1 = "276b24f3ace98bec911be7ff2928d497dc759085"
+uuid = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
+version = "0.2.1"
+
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SortingAlgorithms]]
+deps = ["DataStructures", "Random", "Test"]
+git-tree-sha1 = "03f5898c9959f8115e30bc7226ada7d0df554ddd"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "0.3.1"
 
 [[SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
+[[StaticArrays]]
+deps = ["InteractiveUtils", "LinearAlgebra", "Random", "Statistics", "Test"]
+git-tree-sha1 = "1eb114d6e23a817cd3e99abc3226190876d7c898"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "0.10.2"
+
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[StatsBase]]
+deps = ["DataStructures", "DelimitedFiles", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "Test"]
+git-tree-sha1 = "7b596062316c7d846b67bf625d5963a832528598"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.27.0"
 
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[UUIDs]]
-deps = ["Random"]
+deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]

--- a/Project.toml
+++ b/Project.toml
@@ -6,5 +6,6 @@ version = "0.1.0"
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -68,6 +68,7 @@ function run_benchmarks()
     U  = VelocityFields(g)
     tr = TracerFields(g)
     tt = OperatorTemporaryFields(g)
+    st = StepperTemporaryFields(g)
 
     κh, κv = 4e-2, 4e-2
     𝜈h, 𝜈v = 4e-2, 4e-2
@@ -76,8 +77,8 @@ function run_benchmarks()
     U.v.data  .= rand(eltype(g), size(g))
     U.w.data  .= rand(eltype(g), size(g))
     tr.T.data .= rand(eltype(g), size(g))
-    tt.fCC1.data .= rand(eltype(g), size(g))
-    tt.fCC2.data .= rand(eltype(g), size(g))
+    st.fCC1.data .= rand(eltype(g), size(g))
+    st.fCC2.data .= rand(eltype(g), size(g))
 
     #print("+---------------------------------------------------------------------------------------------------------+\n")
     # print("| ", rpad(" BENCHMARKING OCEANANIGANS: T=$T, (Nx, Ny, Nz)=$N", 103), " |\n")
@@ -118,7 +119,7 @@ function run_benchmarks()
     b = @benchmark 𝜈∇²w!($g, $U.w, $tt.fFZ, $𝜈h, $𝜈h, $tt); pretty_print_summary(b, "𝜈∇²w!");
 
     b = @benchmark ρ!($eos, $g, $tr); pretty_print_summary(b, "ρ!");
-    b = @benchmark solve_poisson_3d_ppn!($g, $tt.fCC1, $tt.fCC2); pretty_print_summary(b, "solve_poisson_3d_ppn!");
+    b = @benchmark solve_poisson_3d_ppn!($g, $st.fCC1, $st.fCC2); pretty_print_summary(b, "solve_poisson_3d_ppn!");
 
     print("└──────────────────────────┴────────────┴──────────┴────────────┴────────────┴────────────┴────────────┴─────────┴───────┘\n")
     # print("+---------------------------------------------------------------------------------------------------------+\n")

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -62,12 +62,12 @@ function run_benchmarks()
     N = (100, 100, 100)
     L = (1000, 1000, 1000)
 
-    g  = RegularCartesianGrid(N, L; dim=3, FloatType=Float32)
+    g  = RegularCartesianGrid(N, L; FloatType=Float64)
     eos = LinearEquationOfState()
 
     U  = VelocityFields(g)
     tr = TracerFields(g)
-    tt = TemporaryFields(g)
+    tt = StepperTemporaryFields(g)
 
     κh, κv = 4e-2, 4e-2
     𝜈h, 𝜈v = 4e-2, 4e-2

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -67,7 +67,7 @@ function run_benchmarks()
 
     U  = VelocityFields(g)
     tr = TracerFields(g)
-    tt = StepperTemporaryFields(g)
+    tt = OperatorTemporaryFields(g)
 
     κh, κv = 4e-2, 4e-2
     𝜈h, 𝜈v = 4e-2, 4e-2

--- a/examples/deep_convection_2d.jl
+++ b/examples/deep_convection_2d.jl
@@ -19,7 +19,7 @@ function make_movies(problem::Problem, R::SavedFields, Nt, Δt)
     animT = @animate for tidx in 1:Int(Nt/R.ΔR)
         print("\rframe = $tidx / $(Int(Nt/R.ΔR))   ")
         Plots.heatmap(g.xC ./ 1000, g.zC ./ 1000, rotl90(R.T[tidx, :, 1, :]) .- 283, color=:balance,
-                      clims=(-0.1, 0),
+                      clims=(-0.02, 0),
                       title="T change @ t=$(tidx*R.ΔR*Δt)")
     end
     mp4(animT, "deep_convection_2d_$(round(Int, time())).mp4", fps = 30)
@@ -37,7 +37,7 @@ end
 function deep_convection_2d()
     Nx, Ny, Nz = 100, 1, 50
     Lx, Ly, Lz = 2000, 1, 1000
-    Nt, Δt = 25000, 20
+    Nt, Δt = 2500, 20
     ΔR = 10
 
     problem = Problem((Nx, Ny, Nz), (Lx, Ly, Lz))

--- a/examples/horizontal_2d.jl
+++ b/examples/horizontal_2d.jl
@@ -1,6 +1,4 @@
-import PyPlot
-using Interact, Plots
-
+using Plots
 using Oceananigans
 
 function make_movies(problem::Problem, R::SavedFields, Nt, Δt)

--- a/examples/isotropic_diffusion_2d.jl
+++ b/examples/isotropic_diffusion_2d.jl
@@ -2,12 +2,8 @@
 # Pkg.activate(".")
 
 using Statistics, Printf
-
 using FFTW
-
-import PyPlot
-using Interact, Plots
-
+using Plots
 using Oceananigans
 
 function make_movies(problem::Problem, R::SavedFields, Nt, Δt)

--- a/examples/rayleigh_taylor_2d.jl
+++ b/examples/rayleigh_taylor_2d.jl
@@ -44,9 +44,9 @@ function make_movies(problem::Problem, R::SavedFields, Nt, Δt)
 end
 
 function rayleigh_taylor_2d()
-    Nx, Ny, Nz = 512, 1, 256
-    Lx, Ly, Lz = 10000, 1, 5000
-    Nt, Δt = 10000, 10
+    Nx, Ny, Nz = 1024, 1, 512
+    Lx, Ly, Lz = 20000, 1, 10000
+    Nt, Δt = 5000, 10
     ΔR = 10
 
     problem = Problem((Nx, Ny, Nz), (Lx, Ly, Lz))

--- a/examples/rising_thermal_bubble.jl
+++ b/examples/rising_thermal_bubble.jl
@@ -2,10 +2,7 @@
 # Pkg.activate(".")
 
 using Statistics, Printf
-
-import PyPlot
-using Interact, Plots
-
+using Plots
 using Oceananigans
 
 function make_movies(problem::Problem, R::SavedFields, Nt, Δt)

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -52,6 +52,10 @@ export
 using
     FFTW
 
+if Base.find_package("CuArrays") !== nothing
+    using CUDAdrv, CUDAnative, CuArrays
+end
+
 abstract type ConstantsCollection end
 abstract type EquationOfStateParameters <: ConstantsCollection end
 abstract type Grid end

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -44,6 +44,7 @@ export
     solve_poisson_3d_ppn,
     solve_poisson_3d_ppn!,
     solve_poisson_3d_ppn_planned!,
+    solve_poisson_3d_ppn_gpu!,
 
     SavedFields,
 

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -62,14 +62,29 @@ end
 
 Construct a `CellField` whose values are defined at the center of a cell.
 """
+# function CellField(grid::Grid)
+#     data = zeros(eltype(grid), size(grid))
+#     CellField{Array{eltype(grid),3}}(data, grid)
+# end
+
 function CellField(grid::Grid)
-    data = zeros(eltype(grid), size(grid))
-    CellField{Array{eltype(grid),3}}(data, grid)
+    if grid.arch == :cpu
+        data = zeros(eltype(grid), size(grid))
+        return CellField{Array{eltype(grid),3}}(data, grid)
+    elseif grid.arch == :gpu
+        data = cu(zeros(eltype(grid), size(grid)))
+        return CellField{CuArray{eltype(grid),3}}(data, grid)
+    end
 end
 
 function CellField(grid::Grid, T)
-    data = zeros(T, size(grid))
-    CellField{Array{T,3}}(data, grid)
+    if grid.arch == :cpu
+        data = zeros(T, size(grid))
+        return CellField{Array{T,3}}(data, grid)
+    elseif grid.arch == :gpu
+        data = cu(zeros(T, size(grid)))
+        return CellField{CuArray{T,3}}(data, grid)
+    end
 end
 
 """
@@ -78,8 +93,13 @@ end
 A `Field` whose values are defined on the x-face of a cell.
 """
 function FaceFieldX(grid::Grid)
-    data = zeros(eltype(grid), size(grid))
-    FaceFieldX{Array{eltype(grid),3}}(data, grid)
+    if grid.arch == :cpu
+        data = zeros(eltype(grid), size(grid))
+        return FaceFieldX{Array{eltype(grid),3}}(data, grid)
+    elseif grid.arch == :gpu
+        data = cu(zeros(eltype(grid), size(grid)))
+        return FaceFieldX{CuArray{eltype(grid),3}}(data, grid)
+    end
 end
 
 """
@@ -88,8 +108,13 @@ end
 A `Field` whose values are defined on the y-face of a cell.
 """
 function FaceFieldY(grid::Grid)
-    data = zeros(eltype(grid), size(grid))
-    FaceFieldY{Array{eltype(grid),3}}(data, grid)
+    if grid.arch == :cpu
+        data = zeros(eltype(grid), size(grid))
+        return FaceFieldY{Array{eltype(grid),3}}(data, grid)
+    elseif grid.arch == :gpu
+        data = cu(zeros(eltype(grid), size(grid)))
+        return FaceFieldY{CuArray{eltype(grid),3}}(data, grid)
+    end
 end
 
 """
@@ -98,13 +123,23 @@ end
 A `Field` whose values are defined on the z-face of a cell.
 """
 function FaceFieldZ(grid::Grid)
-    data = zeros(eltype(grid), size(grid))
-    FaceFieldZ{Array{eltype(grid),3}}(data, grid)
+    if grid.arch == :cpu
+        data = zeros(eltype(grid), size(grid))
+        return FaceFieldZ{Array{eltype(grid),3}}(data, grid)
+    elseif grid.arch == :gpu
+        data = cu(zeros(eltype(grid), size(grid)))
+        return FaceFieldZ{CuArray{eltype(grid),3}}(data, grid)
+    end
 end
 
 function EdgeField(grid::Grid)
-    data = zeros(eltype(grid), size(grid))
-    EdgeField{Array{eltype(grid),3}}(data, grid)
+    if grid.arch == :cpu
+        data = zeros(eltype(grid), size(grid))
+        return EdgeField{Array{eltype(grid),3}}(data, grid)
+    elseif grid.arch == :gpu
+        data = cu(zeros(eltype(grid), size(grid)))
+        return EdgeField{CuArray{eltype(grid),3}}(data, grid)
+    end
 end
 
 @inline size(f::Field) = size(f.grid)

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -9,6 +9,7 @@ T.
 """
 struct RegularCartesianGrid{T<:AbstractFloat} <: Grid
     dim::Int
+    arch::Symbol
     # Number of grid points in (x,y,z).
     Nx::Int
     Ny::Int
@@ -56,7 +57,7 @@ of type T.
 julia> g = RegularCartesianGrid((16, 16, 8), (2π, 2π, 2π))
 ```
 """
-function RegularCartesianGrid(N, L; FloatType=Float64)
+function RegularCartesianGrid(N, L, arch=:cpu; FloatType=Float64)
     @assert length(N) == 3 && length(L) == 3 "N, L must have all three dimensions to specify which dimensions are used."
     @assert all(L .> 0) "Domain lengths must be nonzero and positive!"
 
@@ -88,7 +89,7 @@ function RegularCartesianGrid(N, L; FloatType=Float64)
     yF = 0:Δy:Ly
     zF = 0:-Δz:-Lz
 
-    RegularCartesianGrid{FloatType}(dim, Nx, Ny, Nz, Lx, Ly, Lz, Δx, Δy, Δz, Ax, Ay,
+    RegularCartesianGrid{FloatType}(dim, arch, Nx, Ny, Nz, Lx, Ly, Lz, Δx, Δy, Δz, Ax, Ay,
                             Az, V, xC, yC, zC, xF, yF, zF)
 end
 

--- a/src/operators/ops_regular_cartesian_grid.jl
+++ b/src/operators/ops_regular_cartesian_grid.jl
@@ -85,10 +85,16 @@ southern cells of a cell-centered field `f` and store it in a face-centered
 field `δyf`, assuming both fields are defined on a regular Cartesian grid `g`
 with periodic boundary condition in the \$y\$-direction.
 """
+# function δy!(g::RegularCartesianGrid, f::CellField, δyf::FaceField)
+#     for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds δyf.data[i, j, k] =  f.data[i, j, k] - f.data[i, decmod1(j, g.Ny), k]
+#     end
+#     nothing
+# end
+
 function δy!(g::RegularCartesianGrid, f::CellField, δyf::FaceField)
-    for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds δyf.data[i, j, k] =  f.data[i, j, k] - f.data[i, decmod1(j, g.Ny), k]
-    end
+    @views @. δyf.data[:,     1, :] = f.data[:,     1, :] - f.data[:,     end, :]
+    @views @. δyf.data[:, 2:end, :] = f.data[:, 2:end, :] - f.data[:, 1:end-1, :]
     nothing
 end
 
@@ -100,24 +106,42 @@ southern faces of a face-centered field `f` and store it in a cell-centered
 field `δyf`, assuming both fields are defined on a regular Cartesian grid `g`
 with periodic boundary condition in the \$y\$-direction.
 """
+# function δy!(g::RegularCartesianGrid, f::FaceField, δyf::CellField)
+#     for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds δyf.data[i, j, k] =  f.data[i, incmod1(j, g.Ny), k] - f.data[i, j, k]
+#     end
+#     nothing
+# end
+
 function δy!(g::RegularCartesianGrid, f::FaceField, δyf::CellField)
-    for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds δyf.data[i, j, k] =  f.data[i, incmod1(j, g.Ny), k] - f.data[i, j, k]
-    end
+    @views @. δyf.data[:, 1:end-1, :] = f.data[:, 2:end, :] - f.data[:, 1:end-1, :]
+    @views @. δyf.data[:, end,     :] = f.data[:, 1,     :] - f.data[:, end,     :]
     nothing
 end
+
+# function δy!(g::RegularCartesianGrid, f::EdgeField, δyf::FaceField)
+#     for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds δyf.data[i, j, k] =  f.data[i, incmod1(j, g.Ny), k] - f.data[i, j, k]
+#     end
+#     nothing
+# end
 
 function δy!(g::RegularCartesianGrid, f::EdgeField, δyf::FaceField)
-    for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds δyf.data[i, j, k] =  f.data[i, incmod1(j, g.Ny), k] - f.data[i, j, k]
-    end
+    @views @. δyf.data[:, 1:end-1, :] = f.data[:, 2:end, :] - f.data[:, 1:end-1, :]
+    @views @. δyf.data[:, end,     :] = f.data[:, 1,     :] - f.data[:, end,     :]
     nothing
 end
 
+# function δy!(g::RegularCartesianGrid, f::FaceField, δyf::EdgeField)
+#     for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds δyf.data[i, j, k] =  f.data[i, j, k] - f.data[i, decmod1(j, g.Ny), k]
+#     end
+#     nothing
+# end
+
 function δy!(g::RegularCartesianGrid, f::FaceField, δyf::EdgeField)
-    for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds δyf.data[i, j, k] =  f.data[i, j, k] - f.data[i, decmod1(j, g.Ny), k]
-    end
+    @views @. δyf.data[:,     1, :] = f.data[:,     1, :] - f.data[:,     end, :]
+    @views @. δyf.data[:, 2:end, :] = f.data[:, 2:end, :] - f.data[:, 1:end-1, :]
     nothing
 end
 
@@ -129,11 +153,17 @@ bottom cells of a cell-centered field `f` and store it in a face-centered
 field `δzf`, assuming both fields are defined on a regular Cartesian grid `g`
 with Neumann boundary condition in the \$z\$-direction.
 """
+# function δz!(g::RegularCartesianGrid, f::CellField, δzf::FaceField)
+#     for k in 2:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds δzf.data[i, j, k] = f.data[i, j, k-1] - f.data[i, j, k]
+#     end
+#     @. δzf.data[:, :, 1] = 0
+#     nothing
+# end
+
 function δz!(g::RegularCartesianGrid, f::CellField, δzf::FaceField)
-    for k in 2:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds δzf.data[i, j, k] = f.data[i, j, k-1] - f.data[i, j, k]
-    end
-    @. δzf.data[:, :, 1] = 0
+    @views @. δzf.data[:, :, 2:end] = f.data[:, :, 1:end-1] - f.data[:, :, 2:end]
+    @views @. δzf.data[:, :,     1] = 0
     nothing
 end
 
@@ -145,41 +175,59 @@ bottom faces of a face-centered field `f` and store it in a cell-centered
 field `δzf`, assuming both fields are defined on a regular Cartesian grid `g`
 with Neumann boundary condition in the \$z\$-direction.
 """
+# function δz!(g::RegularCartesianGrid, f::FaceField, δzf::CellField)
+#     for k in 1:(g.Nz-1), j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds δzf.data[i, j, k] =  f.data[i, j, k] - f.data[i, j, k+1]
+#     end
+#     for j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds δzf.data[i, j, g.Nz] = f.data[i, j, g.Nz]
+#     end
+#
+#     # For some reason broadcasting causes 3 memory allocations (78.27 KiB) for
+#     # Nx, Ny, Nz = 100, 100, 100.
+#     # @. δzf.data[:, :, end] = f.data[:, :, end]
+#
+#     nothing
+# end
+
 function δz!(g::RegularCartesianGrid, f::FaceField, δzf::CellField)
-    for k in 1:(g.Nz-1), j in 1:g.Ny, i in 1:g.Nx
-        @inbounds δzf.data[i, j, k] =  f.data[i, j, k] - f.data[i, j, k+1]
-    end
-    for j in 1:g.Ny, i in 1:g.Nx
-        @inbounds δzf.data[i, j, g.Nz] = f.data[i, j, g.Nz]
-    end
-
-    # For some reason broadcasting causes 3 memory allocations (78.27 KiB) for
-    # Nx, Ny, Nz = 100, 100, 100.
-    # @. δzf.data[:, :, end] = f.data[:, :, end]
-
+    @views @. δzf.data[:, :, 1:end-1] = f.data[:, :, 1:end-1] - f.data[:, :, 2:end]
+    @views @. δzf.data[:, :,     end] = f.data[:, :,     end]
     nothing
 end
+
+# function δz!(g::RegularCartesianGrid, f::EdgeField, δzf::FaceField)
+#     for k in 1:(g.Nz-1), j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds δzf.data[i, j, k] =  f.data[i, j, k] - f.data[i, j, k+1]
+#     end
+#     for j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds δzf.data[i, j, g.Nz] = f.data[i, j, g.Nz]
+#     end
+#
+#     # For some reason broadcasting causes 3 memory allocations (78.27 KiB) for
+#     # Nx, Ny, Nz = 100, 100, 100.
+#     # @. δzf.data[:, :, end] = f.data[:, :, end]
+#
+#     nothing
+# end
 
 function δz!(g::RegularCartesianGrid, f::EdgeField, δzf::FaceField)
-    for k in 1:(g.Nz-1), j in 1:g.Ny, i in 1:g.Nx
-        @inbounds δzf.data[i, j, k] =  f.data[i, j, k] - f.data[i, j, k+1]
-    end
-    for j in 1:g.Ny, i in 1:g.Nx
-        @inbounds δzf.data[i, j, g.Nz] = f.data[i, j, g.Nz]
-    end
-
-    # For some reason broadcasting causes 3 memory allocations (78.27 KiB) for
-    # Nx, Ny, Nz = 100, 100, 100.
-    # @. δzf.data[:, :, end] = f.data[:, :, end]
-
+    @views @. δzf.data[:, :, 1:end-1] = f.data[:, :, 1:end-1] - f.data[:, :, 2:end]
+    @views @. δzf.data[:, :,     end] = f.data[:, :,     end]
     nothing
 end
 
+# function δz!(g::RegularCartesianGrid, f::FaceField, δzf::EdgeField)
+#     for k in 2:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds δzf.data[i, j, k] = f.data[i, j, k-1] - f.data[i, j, k]
+#     end
+#     @. δzf.data[:, :, 1] = 0
+#     nothing
+# end
+
 function δz!(g::RegularCartesianGrid, f::FaceField, δzf::EdgeField)
-    for k in 2:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds δzf.data[i, j, k] = f.data[i, j, k-1] - f.data[i, j, k]
-    end
-    @. δzf.data[:, :, 1] = 0
+    @views @. δzf.data[:, :, 2:end] = f.data[:, :, 1:end-1] - f.data[:, :, 2:end]
+    @views @. δzf.data[:, :,     1] = 0
     nothing
 end
 

--- a/src/operators/ops_regular_cartesian_grid.jl
+++ b/src/operators/ops_regular_cartesian_grid.jl
@@ -239,67 +239,122 @@ eastern and western cells of a cell-centered field `f` and store it in a `g`
 face-centered field `favgx`, assuming both fields are defined on a regular
 Cartesian grid `g` with periodic boundary conditions in the \$x\$-direction.
 """
+# function avgx!(g::RegularCartesianGrid, f::CellField, favgx::FaceField)
+#     for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds favgx.data[i, j, k] =  (f.data[i, j, k] + f.data[decmod1(i, g.Nx), j, k]) / 2
+#     end
+# end
+
 function avgx!(g::RegularCartesianGrid, f::CellField, favgx::FaceField)
-    for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds favgx.data[i, j, k] =  (f.data[i, j, k] + f.data[decmod1(i, g.Nx), j, k]) / 2
-    end
+    @views @. favgx.data[2:end, :, :] = (f.data[2:end, :, :] + f.data[1:end-1, :, :]) / 2
+    @views @. favgx.data[1,     :, :] = (f.data[1,     :, :] + f.data[end,     :, :]) / 2
+    nothing
 end
+
+# function avgx!(g::RegularCartesianGrid, f::FaceField, favgx::CellField)
+#     for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds favgx.data[i, j, k] =  (f.data[incmod1(i, g.Nx), j, k] + f.data[i, j, k]) / 2
+#     end
+# end
 
 function avgx!(g::RegularCartesianGrid, f::FaceField, favgx::CellField)
-    for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds favgx.data[i, j, k] =  (f.data[incmod1(i, g.Nx), j, k] + f.data[i, j, k]) / 2
-    end
+    @views @. favgx.data[1:end-1, :, :] = (f.data[2:end, :, :] + f.data[1:end-1, :, :]) / 2
+    @views @. favgx.data[end,     :, :] = (f.data[1,     :, :] + f.data[end,     :, :]) / 2
+    nothing
 end
+
+# function avgx!(g::RegularCartesianGrid, f::FaceField, favgx::EdgeField)
+#     for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds favgx.data[i, j, k] =  (f.data[i, j, k] + f.data[decmod1(i, g.Nx), j, k]) / 2
+#     end
+# end
 
 function avgx!(g::RegularCartesianGrid, f::FaceField, favgx::EdgeField)
-    for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds favgx.data[i, j, k] =  (f.data[i, j, k] + f.data[decmod1(i, g.Nx), j, k]) / 2
-    end
+    @views @. favgx.data[2:end, :, :] = (f.data[2:end, :, :] + f.data[1:end-1, :, :]) / 2
+    @views @. favgx.data[1,     :, :] = (f.data[1,     :, :] + f.data[end,     :, :]) / 2
+    nothing
 end
+
+# function avgy!(g::RegularCartesianGrid, f::CellField, favgy::FaceField)
+#     for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds favgy.data[i, j, k] =  (f.data[i, j, k] + f.data[i, decmod1(j, g.Ny), k]) / 2
+#     end
+# end
 
 function avgy!(g::RegularCartesianGrid, f::CellField, favgy::FaceField)
-    for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds favgy.data[i, j, k] =  (f.data[i, j, k] + f.data[i, decmod1(j, g.Ny), k]) / 2
-    end
+    @views @. favgy.data[:, 2:end, :] = (f.data[:, 2:end, :] + f.data[:, 1:end-1, :]) / 2
+    @views @. favgy.data[:, 1,     :] = (f.data[:, 1,     :] + f.data[:, end,     :]) / 2
+    nothing
 end
+
+# function avgy!(g::RegularCartesianGrid, f::FaceField, favgy::CellField)
+#     for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds favgy.data[i, j, k] =  (f.data[i, incmod1(j, g.Ny), k] + f.data[i, j, k]) / 2
+#     end
+# end
 
 function avgy!(g::RegularCartesianGrid, f::FaceField, favgy::CellField)
-    for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds favgy.data[i, j, k] =  (f.data[i, incmod1(j, g.Ny), k] + f.data[i, j, k]) / 2
-    end
+    @views @. favgy.data[:, 1:end-1, :] = (f.data[:, 2:end, :] + f.data[:, 1:end-1, :]) / 2
+    @views @. favgy.data[:, end,     :] = (f.data[:, 1,     :] + f.data[:, end,     :]) / 2
+    nothing
 end
+
+# function avgy!(g::RegularCartesianGrid, f::FaceField, favgy::EdgeField)
+#     for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds favgy.data[i, j, k] =  (f.data[i, j, k] + f.data[i, decmod1(j, g.Ny), k]) / 2
+#     end
+# end
 
 function avgy!(g::RegularCartesianGrid, f::FaceField, favgy::EdgeField)
-    for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds favgy.data[i, j, k] =  (f.data[i, j, k] + f.data[i, decmod1(j, g.Ny), k]) / 2
-    end
+    @views @. favgy.data[:, 2:end, :] = (f.data[:, 2:end, :] + f.data[:, 1:end-1, :]) / 2
+    @views @. favgy.data[:, 1,     :] = (f.data[:, 1,     :] + f.data[:, end,     :]) / 2
+    nothing
 end
+
+# function avgz!(g::RegularCartesianGrid, f::CellField, favgz::FaceField)
+#     for k in 2:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds favgz.data[i, j, k] =  (f.data[i, j, k] + f.data[i, j, k-1]) / 2
+#     end
+#     @. favgz.data[:, :, 1] = f.data[:, :, 1]
+#     nothing
+# end
 
 function avgz!(g::RegularCartesianGrid, f::CellField, favgz::FaceField)
-    for k in 2:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds favgz.data[i, j, k] =  (f.data[i, j, k] + f.data[i, j, k-1]) / 2
-    end
-    @. favgz.data[:, :, 1] = f.data[:, :, 1]
+    @views @. favgz.data[:, :, 2:end] = (f.data[:, :, 2:end] + f.data[:, :, 1:end-1]) / 2
+    @views @. favgz.data[:, :, 1] = f.data[:, :, 1]
     nothing
 end
+
+# function avgz!(g::RegularCartesianGrid, f::FaceField, favgz::CellField)
+#     for k in 1:(g.Nz-1), j in 1:g.Ny, i in 1:g.Nx
+#         favgz.data[i, j, k] =  (f.data[i, j, incmod1(k, g.Nz)] + f.data[i, j, k]) / 2
+#     end
+#
+#     # Assuming zero at the very bottom, so (f[end] + 0) / 2 = 0.5 * f[end].
+#     @. favgz.data[:, :, end] = 0.5 * f.data[:, :, end]
+#     nothing
+# end
 
 function avgz!(g::RegularCartesianGrid, f::FaceField, favgz::CellField)
-    for k in 1:(g.Nz-1), j in 1:g.Ny, i in 1:g.Nx
-        favgz.data[i, j, k] =  (f.data[i, j, incmod1(k, g.Nz)] + f.data[i, j, k]) / 2
-    end
-
-    # Assuming zero at the very bottom, so (f[end] + 0) / 2 = 0.5 * f[end].
-    @. favgz.data[:, :, end] = 0.5 * f.data[:, :, end]
+    @views @. favgz.data[:, :, 1:end-1] = (f.data[:, :, 2:end] + f.data[:, :, 1:end-1]) / 2
+    @views @. favgz.data[:, :,     end] = 0.5 * f.data[:, :, end]
     nothing
 end
+
+# function avgz!(g::RegularCartesianGrid, f::FaceField, favgz::EdgeField)
+#     for k in 2:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds favgz.data[i, j, k] =  (f.data[i, j, k] + f.data[i, j, k-1]) / 2
+#     end
+#     @. favgz.data[:, :, 1] = f.data[:, :, 1]
+#     nothing
+# end
 
 function avgz!(g::RegularCartesianGrid, f::FaceField, favgz::EdgeField)
-    for k in 2:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds favgz.data[i, j, k] =  (f.data[i, j, k] + f.data[i, j, k-1]) / 2
-    end
-    @. favgz.data[:, :, 1] = f.data[:, :, 1]
+    @views @. favgz.data[:, :, 2:end] = (f.data[:, :, 2:end] + f.data[:, :, 1:end-1]) / 2
+    @views @. favgz.data[:, :, 1] = f.data[:, :, 1]
     nothing
 end
+
 
 """
     div!(g, fx, fy, fz, δfx, δfy, δfz, div)

--- a/src/operators/ops_regular_cartesian_grid.jl
+++ b/src/operators/ops_regular_cartesian_grid.jl
@@ -246,8 +246,8 @@ Cartesian grid `g` with periodic boundary conditions in the \$x\$-direction.
 # end
 
 function avgx!(g::RegularCartesianGrid, f::CellField, favgx::FaceField)
-    @views @. favgx.data[2:end, :, :] = (f.data[2:end, :, :] + f.data[1:end-1, :, :]) / 2
-    @views @. favgx.data[1,     :, :] = (f.data[1,     :, :] + f.data[end,     :, :]) / 2
+    @views @. favgx.data[2:end, :, :] = (f.data[2:end, :, :] + f.data[1:end-1, :, :]) / 2.0f0
+    @views @. favgx.data[1,     :, :] = (f.data[1,     :, :] + f.data[end,     :, :]) / 2.0f0
     nothing
 end
 
@@ -258,8 +258,8 @@ end
 # end
 
 function avgx!(g::RegularCartesianGrid, f::FaceField, favgx::CellField)
-    @views @. favgx.data[1:end-1, :, :] = (f.data[2:end, :, :] + f.data[1:end-1, :, :]) / 2
-    @views @. favgx.data[end,     :, :] = (f.data[1,     :, :] + f.data[end,     :, :]) / 2
+    @views @. favgx.data[1:end-1, :, :] = (f.data[2:end, :, :] + f.data[1:end-1, :, :]) / 2.0f0
+    @views @. favgx.data[end,     :, :] = (f.data[1,     :, :] + f.data[end,     :, :]) / 2.0f0
     nothing
 end
 
@@ -270,8 +270,8 @@ end
 # end
 
 function avgx!(g::RegularCartesianGrid, f::FaceField, favgx::EdgeField)
-    @views @. favgx.data[2:end, :, :] = (f.data[2:end, :, :] + f.data[1:end-1, :, :]) / 2
-    @views @. favgx.data[1,     :, :] = (f.data[1,     :, :] + f.data[end,     :, :]) / 2
+    @views @. favgx.data[2:end, :, :] = (f.data[2:end, :, :] + f.data[1:end-1, :, :]) / 2.0f0
+    @views @. favgx.data[1,     :, :] = (f.data[1,     :, :] + f.data[end,     :, :]) / 2.0f0
     nothing
 end
 
@@ -282,8 +282,8 @@ end
 # end
 
 function avgy!(g::RegularCartesianGrid, f::CellField, favgy::FaceField)
-    @views @. favgy.data[:, 2:end, :] = (f.data[:, 2:end, :] + f.data[:, 1:end-1, :]) / 2
-    @views @. favgy.data[:, 1,     :] = (f.data[:, 1,     :] + f.data[:, end,     :]) / 2
+    @views @. favgy.data[:, 2:end, :] = (f.data[:, 2:end, :] + f.data[:, 1:end-1, :]) / 2.0f0
+    @views @. favgy.data[:, 1,     :] = (f.data[:, 1,     :] + f.data[:, end,     :]) / 2.0f0
     nothing
 end
 
@@ -294,8 +294,8 @@ end
 # end
 
 function avgy!(g::RegularCartesianGrid, f::FaceField, favgy::CellField)
-    @views @. favgy.data[:, 1:end-1, :] = (f.data[:, 2:end, :] + f.data[:, 1:end-1, :]) / 2
-    @views @. favgy.data[:, end,     :] = (f.data[:, 1,     :] + f.data[:, end,     :]) / 2
+    @views @. favgy.data[:, 1:end-1, :] = (f.data[:, 2:end, :] + f.data[:, 1:end-1, :]) / 2.0f0
+    @views @. favgy.data[:, end,     :] = (f.data[:, 1,     :] + f.data[:, end,     :]) / 2.0f0
     nothing
 end
 
@@ -306,8 +306,8 @@ end
 # end
 
 function avgy!(g::RegularCartesianGrid, f::FaceField, favgy::EdgeField)
-    @views @. favgy.data[:, 2:end, :] = (f.data[:, 2:end, :] + f.data[:, 1:end-1, :]) / 2
-    @views @. favgy.data[:, 1,     :] = (f.data[:, 1,     :] + f.data[:, end,     :]) / 2
+    @views @. favgy.data[:, 2:end, :] = (f.data[:, 2:end, :] + f.data[:, 1:end-1, :]) / 2.0f0
+    @views @. favgy.data[:, 1,     :] = (f.data[:, 1,     :] + f.data[:, end,     :]) / 2.0f0
     nothing
 end
 
@@ -320,7 +320,7 @@ end
 # end
 
 function avgz!(g::RegularCartesianGrid, f::CellField, favgz::FaceField)
-    @views @. favgz.data[:, :, 2:end] = (f.data[:, :, 2:end] + f.data[:, :, 1:end-1]) / 2
+    @views @. favgz.data[:, :, 2:end] = (f.data[:, :, 2:end] + f.data[:, :, 1:end-1]) / 2.0f0
     @views @. favgz.data[:, :, 1] = f.data[:, :, 1]
     nothing
 end
@@ -336,7 +336,7 @@ end
 # end
 
 function avgz!(g::RegularCartesianGrid, f::FaceField, favgz::CellField)
-    @views @. favgz.data[:, :, 1:end-1] = (f.data[:, :, 2:end] + f.data[:, :, 1:end-1]) / 2
+    @views @. favgz.data[:, :, 1:end-1] = (f.data[:, :, 2:end] + f.data[:, :, 1:end-1]) / 2.0f0
     @views @. favgz.data[:, :,     end] = 0.5 * f.data[:, :, end]
     nothing
 end
@@ -350,7 +350,7 @@ end
 # end
 
 function avgz!(g::RegularCartesianGrid, f::FaceField, favgz::EdgeField)
-    @views @. favgz.data[:, :, 2:end] = (f.data[:, :, 2:end] + f.data[:, :, 1:end-1]) / 2
+    @views @. favgz.data[:, :, 2:end] = (f.data[:, :, 2:end] + f.data[:, :, 1:end-1]) / 2.0f0
     @views @. favgz.data[:, :, 1] = f.data[:, :, 1]
     nothing
 end

--- a/src/operators/ops_regular_cartesian_grid.jl
+++ b/src/operators/ops_regular_cartesian_grid.jl
@@ -17,10 +17,16 @@ western cells of a cell-centered field `f` and store it in a face-centered
 field `δxf`, assuming both fields are defined on a regular Cartesian grid `g`
 with periodic boundary condition in the \$x\$-direction.
 """
+# function δx!(g::RegularCartesianGrid, f::CellField, δxf::FaceField)
+#     for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds δxf.data[i, j, k] =  f.data[i, j, k] - f.data[decmod1(i, g.Nx), j, k]
+#     end
+#     nothing
+# end
+
 function δx!(g::RegularCartesianGrid, f::CellField, δxf::FaceField)
-    for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds δxf.data[i, j, k] =  f.data[i, j, k] - f.data[decmod1(i, g.Nx), j, k]
-    end
+    @views @. δxf.data[1,     :, :] = f.data[1,     :, :] - f.data[end,     :, :]
+    @views @. δxf.data[2:end, :, :] = f.data[2:end, :, :] - f.data[1:end-1, :, :]
     nothing
 end
 
@@ -32,24 +38,42 @@ western faces of a face-centered field `f` and store it in a cell-centered
 field `δxf`, assuming both fields are defined on a regular Cartesian grid `g`
 with periodic boundary conditions in the \$x\$-direction.
 """
+# function δx!(g::RegularCartesianGrid, f::FaceField, δxf::CellField)
+#     for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds δxf.data[i, j, k] =  f.data[incmod1(i, g.Nx), j, k] - f.data[i, j, k]
+#     end
+#     nothing
+# end
+
 function δx!(g::RegularCartesianGrid, f::FaceField, δxf::CellField)
-    for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds δxf.data[i, j, k] =  f.data[incmod1(i, g.Nx), j, k] - f.data[i, j, k]
-    end
+    @views @. δxf.data[1:end-1, :, :] = f.data[2:end, :, :] - f.data[1:end-1, :, :]
+    @views @. δxf.data[end,     :, :] = f.data[1,     :, :] - f.data[end,     :, :]
     nothing
 end
+
+# function δx!(g::RegularCartesianGrid, f::EdgeField, δxf::FaceField)
+#     for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds δxf.data[i, j, k] =  f.data[incmod1(i, g.Nx), j, k] - f.data[i, j, k]
+#     end
+#     nothing
+# end
 
 function δx!(g::RegularCartesianGrid, f::EdgeField, δxf::FaceField)
-    for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds δxf.data[i, j, k] =  f.data[incmod1(i, g.Nx), j, k] - f.data[i, j, k]
-    end
+    @views @. δxf.data[1:end-1, :, :] = f.data[2:end, :, :] - f.data[1:end-1, :, :]
+    @views @. δxf.data[end,     :, :] = f.data[1,     :, :] - f.data[end,     :, :]
     nothing
 end
 
+# function δx!(g::RegularCartesianGrid, f::FaceField, δxf::EdgeField)
+#     for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+#         @inbounds δxf.data[i, j, k] =  f.data[i, j, k] - f.data[decmod1(i, g.Nx), j, k]
+#     end
+#     nothing
+# end
+
 function δx!(g::RegularCartesianGrid, f::FaceField, δxf::EdgeField)
-    for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
-        @inbounds δxf.data[i, j, k] =  f.data[i, j, k] - f.data[decmod1(i, g.Nx), j, k]
-    end
+    @views @. δxf.data[1,     :, :] = f.data[1,     :, :] - f.data[end,     :, :]
+    @views @. δxf.data[2:end, :, :] = f.data[2:end, :, :] - f.data[1:end-1, :, :]
     nothing
 end
 

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -13,11 +13,13 @@ struct Problem
     ssp::SpectralSolverParameters
 end
 
-function Problem(N, L)
+function Problem(N, L, arch=:cpu, FloatType=Float64)
+    @assert arch == :cpu || arch == :gpu "arch must be :cpu or :gpu"
+
     c = EarthConstants()
     eos = LinearEquationOfState()
 
-    g = RegularCartesianGrid(N, L; FloatType=Float64)
+    g = RegularCartesianGrid(N, L, arch; FloatType=Float64)
 
     U  = VelocityFields(g)
     tr = TracerFields(g)

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -30,7 +30,12 @@ function Problem(N, L, arch=:cpu, FloatType=Float64)
     stmp = StepperTemporaryFields(g)
     otmp = OperatorTemporaryFields(g)
 
-    stmp.fCC1.data .= rand(eltype(g), g.Nx, g.Ny, g.Nz)
+    if arch == :cpu
+        stmp.fCC1.data .= rand(eltype(g), g.Nx, g.Ny, g.Nz)
+    elseif arch == :gpu
+        stmp.fCC1.data .= cu(rand(eltype(g), g.Nx, g.Ny, g.Nz))
+    end
+    
     ssp = SpectralSolverParameters(g, stmp.fCC1, FFTW.PATIENT; verbose=true)
 
     U.u.data  .= 0

--- a/src/spectral_solvers.jl
+++ b/src/spectral_solvers.jl
@@ -385,3 +385,32 @@ function idct_dim3_gpu!(f)
     
     nothing
 end
+
+function solve_poisson_3d_ppn_gpu!(g::RegularCartesianGrid, f::CellField, ϕ::CellField)
+    kx² = cu(zeros(g.Nx, 1))
+    ky² = cu(zeros(g.Ny, 1))
+    kz² = cu(zeros(g.Nz, 1))
+
+    for i in 1:g.Nx; kx²[i] = (2sin((i-1)*π/g.Nx)    / (g.Lx/g.Nx))^2; end
+    for j in 1:g.Ny; ky²[j] = (2sin((j-1)*π/g.Ny)    / (g.Ly/g.Ny))^2; end
+    for k in 1:g.Nz; kz²[k] = (2sin((k-1)*π/(2g.Nz)) / (g.Lz/g.Nz))^2; end
+
+    fft!(f.data, [1, 2])
+    dct_dim3_gpu!(f.data)
+
+    for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+        @inbounds ϕ.data[i, j, k] = -f.data[i, j, k] / (kx²[i] + ky²[j] + kz²[k])
+    end
+    ϕ.data[1, 1, 1] = 0
+
+    ifft!(ϕ.data, [1, 2])
+
+    @. ϕ.data = real(ϕ.data) / (2g.Nz)
+    # for k in 1:g.Nz, j in 1:g.Ny, i in 1:g.Nx
+    #     ϕ[i, j, k] = real(ϕ[i, j, k])
+    # end
+
+    idct_dim3_gpu!(f.data)
+
+    nothing
+end

--- a/src/spectral_solvers.jl
+++ b/src/spectral_solvers.jl
@@ -355,3 +355,33 @@ function solve_poisson_3d_ppn_planned!(ssp::SpectralSolverParameters, g::Regular
     @. ϕ.data = ϕ.data / (2*g.Nz)
     nothing
 end
+
+function dct_dim3_gpu!(f)
+    Nx, Ny, Nz = size(f)
+    f .= cat(f[:, :, 1:2:Nz], f[:, :, Nz:-2:2]; dims=3)
+    fft!(f, 3)
+
+    factors = 2 * exp.(collect(-1im*π*(0:Nz-1) / (2*Nz)))
+    
+    # f .*= repeat(reshape(factors, 1, 1, Nz), Nx, Ny, 1)
+    f .*= cu(repeat(reshape(factors, 1, 1, Nz), Nx, Ny, 1))
+    
+    nothing
+end
+
+function idct_dim3_gpu!(f)
+    Nx, Ny, Nz = size(f)
+    
+    bfactors = 0.5 * exp.(collect(1im*π*(0:Nz-1) / (2*Nz)))
+    # f .*= repeat(reshape(bfactors, 1, 1, Nz), Nx, Ny, 1)
+    f .*= cu(repeat(reshape(bfactors, 1, 1, Nz), Nx, Ny, 1))
+    
+    ifft!(f, 3)
+    
+    # f = cat(f[:, :, 1:Int(Nz/2)], f[:, :, end:-1:Int(Nz/2)+1]; dims=4)
+    # f = reshape(permutedims(f, (1, 2, 4, 3)), Nx, Ny, Nz)
+    # f .= reshape(permutedims(cat(f[:, :, 1:Int(Nz/2)], f[:, :, end:-1:Int(Nz/2)+1]; dims=4), (1, 2, 4, 3)), Nx, Ny, Nz)
+    f .= cu(reshape(permutedims(cat(f[:, :, 1:Int(Nz/2)], f[:, :, end:-1:Int(Nz/2)+1]; dims=4), (1, 2, 4, 3)), Nx, Ny, Nz))
+    
+    nothing
+end

--- a/src/time_steppers.jl
+++ b/src/time_steppers.jl
@@ -102,9 +102,15 @@ function time_stepping!(problem::Problem; Nt, Δt, R)
         RHS = stmp.fCC1
         ϕ   = stmp.fCC2
         div!(g, G.Gu, G.Gv, G.Gw, RHS, otmp)
-        # @time solve_poisson_3d_ppn!(g, RHS, ϕ)
-        solve_poisson_3d_ppn_planned!(ssp, g, RHS, ϕ)
-        @. pr.pNHS.data = real(ϕ.data)
+        
+        if g.arch == :cpu
+            # @time solve_poisson_3d_ppn!(g, RHS, ϕ)
+            solve_poisson_3d_ppn_planned!(ssp, g, RHS, ϕ)
+            @. pr.pNHS.data = real(ϕ.data)
+        elseif g.arch == :gpu
+            solve_poisson_3d_ppn_gpu!(g, RHS, ϕ)
+            @. pr.pNHS.data = real(ϕ.data)
+        end
 
         # div!(g, G.Gu, G.Gv, G.Gw, RHS, otmp)
         # RHSr = real.(RHS.data)


### PR DESCRIPTION
Coded some difference and averaging operators using the `@views` macro. Just a proof of concept right now as the model goes run on a GPU when creating a `Problem` with `arch=:gpu`, but because the kernels are very small (and there are many of them) it's very slow. At least we have something that runs, now we can worry about how to optimize for performance.

Some hacks were used to get this to work but the operators and time stepping is completely shared. The only bit that is different is the quasi-spectral solver as cuFFT does not perform R2R or DCT transforms (`FFTW.REDFT01` and `FFTW.REDFT10`) in particular. A GPU-compatible DCT/IDCT transform was coded that calculates the DCT/IDCT in terms of  `fft!` and `ifft!`.