### PR TITLE
Support for user-defined forcing functions.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -54,9 +54,9 @@ uuid = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
 
 [[CUDAapi]]
 deps = ["Libdl", "Logging", "Test"]
-git-tree-sha1 = "350cde12f25d297609369a9acb4c6214211675db"
+git-tree-sha1 = "e1f551ad1c03b3fa2a966794ead05772bff4b064"
 uuid = "3895d2a7-ec45-59b8-82bb-cfc6a382f9b3"
-version = "0.5.4"
+version = "0.6.0"
 
 [[CUDAdrv]]
 deps = ["CUDAapi", "Libdl", "Printf", "Test"]
@@ -121,7 +121,7 @@ uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
 version = "0.0.10"
 
 [[Distributed]]
-deps = ["Random", "Serialization", "Sockets"]
+deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[FFTW]]
@@ -150,9 +150,9 @@ version = "0.3.5"
 
 [[ForwardDiff]]
 deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "InteractiveUtils", "LinearAlgebra", "NaNMath", "Random", "SparseArrays", "SpecialFunctions", "StaticArrays", "Test"]
-git-tree-sha1 = "e393bd3b9102659fb24fe88caedec41f2bc2e7de"
+git-tree-sha1 = "4c4d727f1b7e0092134fabfab6396b8945c1ea5b"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.2"
+version = "0.10.3"
 
 [[GPUArrays]]
 deps = ["Adapt", "FFTW", "FillArrays", "LinearAlgebra", "Printf", "Random", "Serialization", "StaticArrays", "Test"]
@@ -185,7 +185,7 @@ uuid = "d9be37ee-ecc9-5288-90f1-b9ca67657a75"
 version = "0.7.1"
 
 [[InteractiveUtils]]
-deps = ["Markdown"]
+deps = ["LinearAlgebra", "Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JLD]]
@@ -362,7 +362,7 @@ uuid = "30578b45-9adc-5946-b283-645ec420af67"
 version = "0.4.0"
 
 [[UUIDs]]
-deps = ["Random", "SHA"]
+deps = ["Random"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]

--- a/examples/deep_convection_3d.jl
+++ b/examples/deep_convection_3d.jl
@@ -5,12 +5,26 @@ using Oceananigans
 function deep_convection_3d()
     Nx, Ny, Nz = 100, 100, 50
     Lx, Ly, Lz = 2000, 2000, 1000
-    Nt, Δt = 500, 20
+    Nt, Δt = 1000, 20
 
     model = Model((Nx, Ny, Nz), (Lx, Ly, Lz))
-    impose_initial_conditions!(model)
 
-    nc_writer = NetCDFFieldWriter(".", "deep_convection_3d", 50)
+    # impose_initial_conditions!(model)
+
+    # We will impose a surface heat flux of -800 W/m² ≈ -9e-6 K/s  in a square
+    # on the surface of the domain.
+    @inline function surface_cooling_disk(u, v, w, T, S, Nx, Ny, Nz, Δx, Δy, Δz, i, j, k)
+        if k == 1 && (20 < i < 80) && (20 < j < 80)
+            return -9e-6
+        else
+            return 0
+        end
+    end
+
+    # Only impose surface_cooling_disk on the temperature field.
+    model.forcing = Forcing(nothing, nothing, nothing, surface_cooling_disk, nothing)
+
+    nc_writer = NetCDFFieldWriter(".", "deep_convection_3d", 20)
     push!(model.output_writers, nc_writer)
 
     time_step!(model; Nt=Nt, Δt=Δt)
@@ -55,6 +69,7 @@ function impose_cooling_disk!(model::Model)
     # source terms at each time step. Also convert surface heat flux [W/m²]
     # into a temperature tendency forcing [K/s].
     @. model.forcings.FT.data[:, :, 1] = (Q / cᵥ) * (g.Az / (model.eos.ρ₀ * g.V))
+    @show model.forcings.FT.data[50, 50, 1]
     nothing
 end
 

--- a/examples/deep_convection_3d.jl
+++ b/examples/deep_convection_3d.jl
@@ -2,35 +2,6 @@ using Statistics: mean
 using Plots
 using Oceananigans
 
-function deep_convection_3d()
-    Nx, Ny, Nz = 100, 100, 50
-    Lx, Ly, Lz = 2000, 2000, 1000
-    Nt, Δt = 1000, 20
-
-    model = Model((Nx, Ny, Nz), (Lx, Ly, Lz))
-
-    # impose_initial_conditions!(model)
-
-    # We will impose a surface heat flux of -800 W/m² ≈ -9e-6 K/s  in a square
-    # on the surface of the domain.
-    @inline function surface_cooling_disk(u, v, w, T, S, Nx, Ny, Nz, Δx, Δy, Δz, i, j, k)
-        if k == 1 && (20 < i < 80) && (20 < j < 80)
-            return -9e-6
-        else
-            return 0
-        end
-    end
-
-    # Only impose surface_cooling_disk on the temperature field.
-    model.forcing = Forcing(nothing, nothing, nothing, surface_cooling_disk, nothing)
-
-    nc_writer = NetCDFFieldWriter(".", "deep_convection_3d", 20)
-    push!(model.output_writers, nc_writer)
-
-    time_step!(model; Nt=Nt, Δt=Δt)
-    # make_temperature_movies(model, field_writer)
-end
-
 function impose_cooling_disk!(model::Model)
     g = model.grid
     c = model.constants
@@ -115,3 +86,24 @@ end
 #     end
 #     mp4(movie, "deep_convection_3d_$(round(Int, time())).mp4", fps = 30)
 # end
+
+Nx, Ny, Nz = 100, 100, 50
+Lx, Ly, Lz = 2000, 2000, 1000
+Nt, Δt = 1000, 20
+
+model = Model((Nx, Ny, Nz), (Lx, Ly, Lz))
+
+# impose_initial_conditions!(model)
+
+# We will impose a surface heat flux of -800 W/m² ≈ -9e-6 K/s  in a square
+# on the surface of the domain.
+@inline surface_cooling_disk(u, v, w, T, S, Nx, Ny, Nz, Δx, Δy, Δz, i, j, k) = ifelse(k == 1 && 20 < i < 80 && 20 < j < 80, -9e-6, 0)
+
+# Only impose surface_cooling_disk on the temperature field.
+model.forcing = Forcing(nothing, nothing, nothing, surface_cooling_disk, nothing)
+
+nc_writer = NetCDFFieldWriter(".", "deep_convection_3d", 20)
+push!(model.output_writers, nc_writer)
+
+time_step!(model; Nt=Nt, Δt=Δt)
+# make_temperature_movies(model, field_writer)

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -31,6 +31,8 @@ export
     OperatorTemporaryFields,
     StepperTemporaryFields,
 
+    Forcing,
+
     LinearEquationOfState,
     ρ!,
     δρ!,
@@ -104,6 +106,7 @@ include("planetary_constants.jl")
 include("grids.jl")
 include("fields.jl")
 include("fieldsets.jl")
+include("forcing.jl")
 
 include("operators/operators.jl")
 

--- a/src/forcing.jl
+++ b/src/forcing.jl
@@ -1,0 +1,28 @@
+struct Forcing{Tu,Tv,Tw,TT,TS}
+  u::Tu
+  v::Tv
+  w::Tw
+  T::TT
+  S::TS
+end
+
+@inline zero_func(u, v, w, T, S, Nx, Ny, Nz, Δx, Δy, Δz, i, j, k) = 0
+
+function Forcing(Tu, Tv, Tw, TT, TS)
+    if Tu == nothing
+        Tu = zero_func
+    end
+    if Tv == nothing
+        Tv = zero_func
+    end
+    if Tw == nothing
+        Tw = zero_func
+    end
+    if TT == nothing
+        TT = zero_func
+    end
+    if TS == nothing
+        TS = zero_func
+    end
+    Forcing{typeof(Tu),typeof(Tv),typeof(Tw),typeof(TT),typeof(Tu)}(Tu, Tv, Tw, TT, TS)
+end

--- a/src/forcing.jl
+++ b/src/forcing.jl
@@ -1,28 +1,28 @@
+"Dummy function and forcing default."
+@inline zero_func(args...) = 0
+
+"""
+    Forcing(Fu, Fv, Fw, FF, FS)
+
+    Forcing(; Fu=zero_func, Fv=zero_func, Fw=zero_func, FT=zero_func, FS=zero_func)
+
+Construct a `Forcing` to specify functions that force `u`, `v`, `w`, `T`, and `S`. 
+Forcing functions default to `zero_func`, which does nothing.
+"""
 struct Forcing{Tu,Tv,Tw,TT,TS}
-  u::Tu
-  v::Tv
-  w::Tw
-  T::TT
-  S::TS
+    u::Tu
+    v::Tv
+    w::Tw
+    T::TT
+    S::TS
+    function Forcing(Fu, Fv, Fw, FT, FS)
+        Fu = Fu === nothing ? zero_func : Fu
+        Fv = Fv === nothing ? zero_func : Fv
+        Fw = Fw === nothing ? zero_func : Fw
+        FT = FT === nothing ? zero_func : FT
+        FS = FS === nothing ? zero_func : FS
+        new{typeof(Fu),typeof(Fv),typeof(Fw),typeof(FT),typeof(FS)}(Fu, Fv, Fw, FT, FS)
+    end
 end
 
-@inline zero_func(u, v, w, T, S, Nx, Ny, Nz, Δx, Δy, Δz, i, j, k) = 0
-
-function Forcing(Tu, Tv, Tw, TT, TS)
-    if Tu == nothing
-        Tu = zero_func
-    end
-    if Tv == nothing
-        Tv = zero_func
-    end
-    if Tw == nothing
-        Tw = zero_func
-    end
-    if TT == nothing
-        TT = zero_func
-    end
-    if TS == nothing
-        TS = zero_func
-    end
-    Forcing{typeof(Tu),typeof(Tv),typeof(Tw),typeof(TT),typeof(Tu)}(Tu, Tv, Tw, TT, TS)
-end
+Forcing(; Fu=nothing, Fv=nothing, Fw=nothing, FT=nothing, FS=nothing) = Forcing(Fu, Fv, Fw, FT, FS)

--- a/src/model.jl
+++ b/src/model.jl
@@ -22,7 +22,7 @@ end
 function Model(N, L, arch=:cpu, float_type=Float64)
     metadata = _ModelMetadata(arch, float_type)
     configuration = _ModelConfiguration(4e-2, 4e-2, 4e-2, 4e-2)
-    boundary_conditions = BoundaryConditions(:periodic, :periodic, :rigid_lid, :free_slip)
+    boundary_conditions = _BoundaryConditions(:periodic, :periodic, :rigid_lid, :free_slip)
 
     constants = Earth()
     eos = LinearEquationOfState()

--- a/src/model.jl
+++ b/src/model.jl
@@ -11,6 +11,7 @@ mutable struct Model
     G::SourceTerms
     Gp::SourceTerms
     forcings::ForcingFields
+    forcing::Forcing
     stepper_tmp::StepperTemporaryFields
     operator_tmp::OperatorTemporaryFields
     ssp  # ::SpectralSolverParameters or ::SpectralSolverParametersGPU
@@ -37,6 +38,8 @@ function Model(N, L, arch=:cpu, float_type=Float64)
     forcings = ForcingFields(metadata, grid)
     stepper_tmp = StepperTemporaryFields(metadata, grid)
     operator_tmp = OperatorTemporaryFields(metadata, grid)
+
+    forcing = Forcing(nothing, nothing, nothing, nothing, nothing)
 
     time, time_step, Δt = 0, 0, 0
     clock = Clock(time, time_step, Δt)
@@ -71,6 +74,6 @@ function Model(N, L, arch=:cpu, float_type=Float64)
     ρ!(eos, grid, tracers)
 
     Model(metadata, configuration, boundary_conditions, constants, eos, grid,
-          velocities, tracers, pressures, G, Gp, forcings,
+          velocities, tracers, pressures, G, Gp, forcings, forcing,
           stepper_tmp, operator_tmp, ssp, clock, output_writers, diagnostics)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -385,4 +385,19 @@ using Oceananigans.Operators
         Oceananigans.Operators.𝜈∇²w!(g, w, 𝜈_lap_w, 𝜈h, 𝜈v, otmp)
         for idx in test_indices; @test 𝜈∇²w(w.data, 𝜈h, 𝜈v, g.Nx, g.Ny, g.Nz, g.Δx, g.Δy, g.Δz, idx...) ≈ 𝜈_lap_w.data[idx...]; end
     end
-end
+
+    @testset "Forcing" begin
+        add_one(args...) = 1.0
+        function test_forcing(fld)
+            kwarg = Dict(Symbol(:F, fld)=>add_one)
+            forcing = Forcing(; kwarg...)
+            f = getfield(forcing, fld)
+            f() == 1.0
+        end
+
+        for fld in [:u, :v, :w, :T, :S]
+            @test test_forcing(fld)
+        end
+    end
+
+end # Oceananigans tests


### PR DESCRIPTION
Just hacked something together that allows for user-defined forcing functions for the CPU. Have not tested on the GPU yet.

Basically there's a struct `Forcing` that stores the user-defined forcing functions. It will replace the old `ForcingFields` struct. See `examples/deep_convection_3d.jl` for how I switched to using a forcing function for T to enforce a cooling surface heat flux.

A big issue is that the current implementation slows down the time stepping by a factor of 2-3x. So we'll have to figure out why before merging.

The function must have a signature like `F(u, v, w, T, S, Nx, Ny, Nz, Δx, Δy, Δz, i, j, k)` right now so this won't produce a nice solution as we will have to figure out #59 before the function signature can look as nice as `surface_cooling_disk(grid, velocities, tracers, i, j, k)`. This is work for another branch.

Will keep working on this before merging. Just wanted to start something.

Resolves #73 