### PR TITLE
read_output function for NetCDF.

### DIFF
--- a/src/output_writers.jl
+++ b/src/output_writers.jl
@@ -113,17 +113,23 @@ function write_output(model::Model, fw::NetCDFFieldWriter)
 
     isfile(nc_filepath) && rm(nc_filepath)
 
-    nccreate(nc_filepath, "u", "xC", xF, xF_attr, "yC", yC, yC_attr, "zC", zC, zC_attr, atts=u_attr, compress=5)
+    nccreate(nc_filepath, "u", "xC", xC, xC_attr, "yC", yC, yC_attr, "zC", zC, zC_attr, atts=u_attr, compress=5)
     ncwrite(model.velocities.u.data, nc_filepath, "u")
 
-    nccreate(nc_filepath, "v", "xC", xF, xF_attr, "yC", yC, yC_attr, "zC", zC, zC_attr, atts=v_attr, compress=5)
+    nccreate(nc_filepath, "v", "xC", xC, xC_attr, "yC", yC, yC_attr, "zC", zC, zC_attr, atts=v_attr, compress=5)
     ncwrite(model.velocities.v.data, nc_filepath, "v")
 
-    nccreate(nc_filepath, "w", "xC", xF, xF_attr, "yC", yC, yC_attr, "zC", zC, zC_attr, atts=w_attr, compress=5)
+    nccreate(nc_filepath, "w", "xC", xC, xC_attr, "yC", yC, yC_attr, "zC", zC, zC_attr, atts=w_attr, compress=5)
     ncwrite(model.velocities.w.data, nc_filepath, "w")
 
     nccreate(nc_filepath, "T", "xC", xC, xC_attr, "yC", yC, yC_attr, "zC", zC, zC_attr, atts=T_attr, compress=5)
     ncwrite(model.tracers.T.data, nc_filepath, "T")
 
     ncclose(nc_filename)
+end
+
+function read_output(fw::NetCDFFieldWriter, field_name, iter)
+    nc_filename = fw.filename_prefix * "_" * lpad(iter, 9, "0") * ".nc"
+    nc_filepath = joinpath(fw.dir, nc_filename)
+    ncread(nc_filepath, field_name)
 end


### PR DESCRIPTION
Just merging this so I can work on cleaning up the examples.

Couple of NetCDF related issues I hit:
* [NetCDF.jl](https://github.com/JuliaGeo/NetCDF.jl) seems to be missing some features and isn't really being maintained (See https://github.com/JuliaGeo/NetCDF.jl/issues/62 about saving time values and https://github.com/JuliaGeo/NetCDF.jl/issues/39). Maybe it's worth switching to [NCDatasets.jl](https://github.com/Alexander-Barth/NCDatasets.jl) which takes a more data frames approach to NetCDF and is actively maintained and grew out of bugs that weren't being fixed in NetCDF.jl. Unfortunately we're choosing between two relatively young packages. An alternative would be to use the much more mature [netcdf4-python](http://unidata.github.io/netcdf4-python/) but I'd rather not have to use PyCall...
* We might need to decide on some standard field/variable names. #91
* Output might need to take into account cell-centered and face-centered fields #92

Reopens #31 